### PR TITLE
Add RequestTimingSample.NetworkDuration (pure wire time)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.1.0]
+### Add
+- `RequestTimingSample.NetworkDuration`: pure wire round-trip time of the final `HttpClient.SendAsync` attempt, measured on the ThreadPool inside the send's `Task.Run`. Unlike `Duration` (which brackets the whole `SendHttp*` call and therefore includes Task scheduling, middleware, inter-retry Polly backoff, and — critically — the `SynchronizationContext` post-back to the caller), `NetworkDuration` excludes all caller-thread scheduling latency, so a stalled/janky caller thread no longer inflates it. Consumers driving a connection-quality/latency EWMA should prefer `NetworkDuration` over `Duration`. `TimeSpan.Zero` when no send attempt completed (e.g. aborted before the wire call). Additive: `Duration` is unchanged.
+
+### Note
+- `RequestTimingSample`'s constructor gains a `networkDuration` parameter (positioned right after `duration`). The struct is only constructed inside the library (`ApiClient.EmitTiming`); external code consumes the sample and is unaffected.
+
 ## [2.0.2]
 ### Changes:
 - ApiClient no longer logs request errors (non-success 4xx/5xx status codes). Reporting request outcomes is now the responsibility of the consumer, which can inspect the returned `IHttpResponse` (`StatusCode`, `IsClientError`/`IsServerError`). No change to default behaviour: request-error logging was already gated behind `ApiClientOptions.VerboseLogging` (off by default). Other verbose diagnostics (download progress, stream messages, range-download warnings) are unchanged.

--- a/Runtime/ApiClient.cs
+++ b/Runtime/ApiClient.cs
@@ -152,8 +152,18 @@ namespace ApiClient.Runtime
         // Emits one RequestTimingSample for a completed call. Tolerant of any null
         // input — only the duration is required to be meaningful. Subscriber exceptions
         // are swallowed so a buggy listener can't poison the send pipeline.
+        // Elapsed since a Stopwatch.GetTimestamp() reading, as a TimeSpan. Allocation-free
+        // (no Stopwatch instance) so it can bracket every SendAsync attempt cheaply.
+        private static TimeSpan StopwatchElapsedSince(long startTimestamp)
+        {
+            var delta = Stopwatch.GetTimestamp() - startTimestamp;
+            if (delta <= 0) return TimeSpan.Zero;
+            return TimeSpan.FromTicks(delta * TimeSpan.TicksPerSecond / Stopwatch.Frequency);
+        }
+
         private void EmitTiming(
             Stopwatch sw,
+            TimeSpan networkDuration,
             IHttpResponse response,
             HttpMethod method,
             string requestUri,
@@ -181,6 +191,7 @@ namespace ApiClient.Runtime
 
             var sample = new RequestTimingSample(
                 sw.Elapsed,
+                networkDuration,
                 isSuccess,
                 isFromCache,
                 method,
@@ -215,6 +226,9 @@ namespace ApiClient.Runtime
             var __uri = req?.RequestMessage?.RequestUri?.ToString();
             var __lane = req?.PriorityLane;
             var __sw = Stopwatch.StartNew();
+            // Pure wire time of the final SendAsync attempt (ThreadPool-measured, excludes the
+            // sync-context post-back) — see RequestTimingSample.NetworkDuration.
+            TimeSpan __wire = TimeSpan.Zero;
             IHttpResponse __final = null;
             try
             {
@@ -249,7 +263,9 @@ namespace ApiClient.Runtime
 
                         try
                         {
+                            var __wireStart = Stopwatch.GetTimestamp();
                             using var responseMessage = await _httpClient.SendAsync(request.RequestMessage, request.CancellationToken);
+                            __wire = StopwatchElapsedSince(__wireStart);
                             response = new HttpResponse(
                                 request.RequestMessage,
                                 responseMessage.Headers,
@@ -285,7 +301,7 @@ namespace ApiClient.Runtime
             }
             finally
             {
-                EmitTiming(__sw, __final, __method, __uri, __lane);
+                EmitTiming(__sw, __wire, __final, __method, __uri, __lane);
             }
         }
 
@@ -307,6 +323,7 @@ namespace ApiClient.Runtime
             var __uri = req?.RequestMessage?.RequestUri?.ToString();
             var __lane = req?.PriorityLane;
             var __sw = Stopwatch.StartNew();
+            TimeSpan __wire = TimeSpan.Zero;
             IHttpResponse __final = null;
             try
             {
@@ -343,7 +360,9 @@ namespace ApiClient.Runtime
 
                         try
                         {
+                            var __wireStart = Stopwatch.GetTimestamp();
                             using var responseMessage = await _httpClient.SendAsync(request.RequestMessage, request.CancellationToken);
+                            __wire = StopwatchElapsedSince(__wireStart);
 
                             var (error, body, errorResponse) = await ProcessJsonErrorResponse<E>(responseMessage, request.RequestMessage);
 
@@ -386,7 +405,7 @@ namespace ApiClient.Runtime
             }
             finally
             {
-                EmitTiming(__sw, __final, __method, __uri, __lane);
+                EmitTiming(__sw, __wire, __final, __method, __uri, __lane);
             }
         }
 
@@ -407,6 +426,7 @@ namespace ApiClient.Runtime
             var __uri = req?.RequestMessage?.RequestUri?.ToString();
             var __lane = req?.PriorityLane;
             var __sw = Stopwatch.StartNew();
+            TimeSpan __wire = TimeSpan.Zero;
             IHttpResponse __final = null;
             try
             {
@@ -442,7 +462,9 @@ namespace ApiClient.Runtime
                         Profiler.BeginSample($"Api Client Execute Request: {request.Uri}");
                         try
                         {
+                            var __wireStart = Stopwatch.GetTimestamp();
                             using var responseMessage = await _httpClient.SendAsync(request.RequestMessage, request.CancellationToken);
+                            __wire = StopwatchElapsedSince(__wireStart);
 
                             var (content, error, body, errorResponse) = await ProcessJsonResponse<T, E>(responseMessage, request.RequestMessage);
 
@@ -486,7 +508,7 @@ namespace ApiClient.Runtime
             }
             finally
             {
-                EmitTiming(__sw, __final, __method, __uri, __lane);
+                EmitTiming(__sw, __wire, __final, __method, __uri, __lane);
             }
         }
 
@@ -497,6 +519,7 @@ namespace ApiClient.Runtime
             var __uri = req?.RequestMessage?.RequestUri?.ToString();
             var __lane = req?.PriorityLane;
             var __sw = Stopwatch.StartNew();
+            TimeSpan __wire = TimeSpan.Zero;
             IHttpResponse __final = null;
             try
             {
@@ -531,10 +554,12 @@ namespace ApiClient.Runtime
 
                         try
                         {
+                            var __wireStart = Stopwatch.GetTimestamp();
                             using var responseMessage = await _httpClient.SendAsync(
                                 request.RequestMessage,
                                 HttpCompletionOption.ResponseHeadersRead,
                                 request.CancellationToken);
+                            __wire = StopwatchElapsedSince(__wireStart);
 
                             if (!responseMessage.IsSuccessStatusCode)
                             {
@@ -585,7 +610,7 @@ namespace ApiClient.Runtime
             }
             finally
             {
-                EmitTiming(__sw, __final, __method, __uri, __lane);
+                EmitTiming(__sw, __wire, __final, __method, __uri, __lane);
             }
         }
 

--- a/Runtime/ApiClient.cs
+++ b/Runtime/ApiClient.cs
@@ -158,7 +158,10 @@ namespace ApiClient.Runtime
         {
             var delta = Stopwatch.GetTimestamp() - startTimestamp;
             if (delta <= 0) return TimeSpan.Zero;
-            return TimeSpan.FromTicks(delta * TimeSpan.TicksPerSecond / Stopwatch.Frequency);
+            // double-based conversion: `delta * TicksPerSecond` can overflow long for a very
+            // long-running / hung send and wrap to a negative TimeSpan. double avoids the
+            // overflow and still keeps full tick precision after the divide.
+            return TimeSpan.FromTicks((long)(delta * (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency));
         }
 
         private void EmitTiming(
@@ -263,6 +266,7 @@ namespace ApiClient.Runtime
 
                         try
                         {
+                            __wire = TimeSpan.Zero; // reset per attempt so a prior attempt's time can't leak
                             var __wireStart = Stopwatch.GetTimestamp();
                             using var responseMessage = await _httpClient.SendAsync(request.RequestMessage, request.CancellationToken);
                             __wire = StopwatchElapsedSince(__wireStart);
@@ -360,6 +364,7 @@ namespace ApiClient.Runtime
 
                         try
                         {
+                            __wire = TimeSpan.Zero; // reset per attempt so a prior attempt's time can't leak
                             var __wireStart = Stopwatch.GetTimestamp();
                             using var responseMessage = await _httpClient.SendAsync(request.RequestMessage, request.CancellationToken);
                             __wire = StopwatchElapsedSince(__wireStart);
@@ -462,6 +467,7 @@ namespace ApiClient.Runtime
                         Profiler.BeginSample($"Api Client Execute Request: {request.Uri}");
                         try
                         {
+                            __wire = TimeSpan.Zero; // reset per attempt so a prior attempt's time can't leak
                             var __wireStart = Stopwatch.GetTimestamp();
                             using var responseMessage = await _httpClient.SendAsync(request.RequestMessage, request.CancellationToken);
                             __wire = StopwatchElapsedSince(__wireStart);
@@ -554,6 +560,7 @@ namespace ApiClient.Runtime
 
                         try
                         {
+                            __wire = TimeSpan.Zero; // reset per attempt so a prior attempt's time can't leak
                             var __wireStart = Stopwatch.GetTimestamp();
                             using var responseMessage = await _httpClient.SendAsync(
                                 request.RequestMessage,

--- a/Runtime/RequestTimingSample.cs
+++ b/Runtime/RequestTimingSample.cs
@@ -19,8 +19,18 @@ namespace ApiClient.Runtime
     /// post back to the caller. It is not pure network RTT — but it IS what an end
     /// user feels.</para>
     ///
+    /// <para><see cref="NetworkDuration"/>, by contrast, brackets ONLY the
+    /// <c>HttpClient.SendAsync</c> call of the final attempt — measured on the ThreadPool
+    /// inside the send's <see cref="System.Threading.Tasks.Task"/>. It excludes Task
+    /// scheduling, middleware, Polly backoff between retries, and the
+    /// <see cref="System.Threading.SynchronizationContext"/> post back to the caller. It is
+    /// the closest thing to pure server round-trip time and is NOT inflated by a stalled
+    /// caller thread — prefer it for connection-quality / latency EWMAs.</para>
+    ///
     /// <para>For a connection-quality EWMA, consumers should:</para>
     /// <list type="bullet">
+    /// <item>Prefer <see cref="NetworkDuration"/> over <see cref="Duration"/> — the latter
+    /// includes caller-thread scheduling latency and is not a network measurement.</item>
     /// <item>Skip when <see cref="IsSuccess"/> is false (aborts/timeouts/network errors
     /// have meaningless durations).</item>
     /// <item>Skip when <see cref="IsFromCache"/> is true (cached responses return
@@ -31,6 +41,7 @@ namespace ApiClient.Runtime
     {
         public RequestTimingSample(
             TimeSpan duration,
+            TimeSpan networkDuration,
             bool isSuccess,
             bool isFromCache,
             HttpMethod method,
@@ -39,6 +50,7 @@ namespace ApiClient.Runtime
             string priorityLane)
         {
             Duration = duration;
+            NetworkDuration = networkDuration;
             IsSuccess = isSuccess;
             IsFromCache = isFromCache;
             Method = method;
@@ -50,6 +62,15 @@ namespace ApiClient.Runtime
         /// <summary>Wall-clock duration from the public <c>SendHttp*</c> entry point
         /// to the moment the response is handed back to the caller.</summary>
         public TimeSpan Duration { get; }
+
+        /// <summary>
+        /// Round-trip time of the final <c>HttpClient.SendAsync</c> attempt only, measured on
+        /// the ThreadPool. Excludes Task scheduling, middleware, inter-retry backoff and the
+        /// SynchronizationContext post-back, so a stalled caller thread does NOT inflate it.
+        /// This is the value to feed a network-latency EWMA. <see cref="TimeSpan.Zero"/> when
+        /// no send attempt completed (e.g. aborted before the wire call).
+        /// </summary>
+        public TimeSpan NetworkDuration { get; }
 
         /// <summary>
         /// True when bytes flowed end-to-end and the response is not an abort, timeout,

--- a/Runtime/RequestTimingSample.cs
+++ b/Runtime/RequestTimingSample.cs
@@ -39,6 +39,23 @@ namespace ApiClient.Runtime
     /// </remarks>
     public readonly struct RequestTimingSample
     {
+        /// <summary>
+        /// Back-compat overload matching the pre-2.1.0 signature (no wire time). Forwards with
+        /// <see cref="NetworkDuration"/> = <see cref="TimeSpan.Zero"/> so existing callers keep
+        /// compiling; new code should pass a measured wire duration to the primary constructor.
+        /// </summary>
+        public RequestTimingSample(
+            TimeSpan duration,
+            bool isSuccess,
+            bool isFromCache,
+            HttpMethod method,
+            string requestUri,
+            HttpStatusCode? statusCode,
+            string priorityLane)
+            : this(duration, TimeSpan.Zero, isSuccess, isFromCache, method, requestUri, statusCode, priorityLane)
+        {
+        }
+
         public RequestTimingSample(
             TimeSpan duration,
             TimeSpan networkDuration,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.realitygames.apiclient",
-    "version": "2.0.2",
+    "version": "2.1.0",
     "displayName": "Api Client",
     "description": "",
     "unity": "2019.4",


### PR DESCRIPTION
Duration brackets the whole SendHttp* call, including the SynchronizationContext post-back to the caller, so a stalled/janky caller thread inflates it and it is not a network measurement. Consumers driving a connection-quality EWMA were reading caller-thread scheduling latency as fake network latency.

Add NetworkDuration: the round-trip of the final HttpClient.SendAsync attempt only, timed with Stopwatch.GetTimestamp() inside the send's Task.Run (new StopwatchElapsedSince helper). Excludes Task scheduling, middleware, inter-retry Polly backoff and the sync-context hop. Measured in all four RTT-emitting senders; RequestTimingSample's ctor gains a networkDuration param (constructed only inside EmitTiming). Additive - Duration unchanged. Bump 2.0.2 -> 2.1.0.